### PR TITLE
Continuous integration on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,19 +3,17 @@
 language: perl
 
 perl:
-#  - "5.16"
+  - "5.16"
   - "5.14"
   - "5.12"
-#  - "5.10"
+  - "5.10"
 
 compiler:
   - clang
   - gcc
 
 install:
-  - echo "Using compiler: $CC"
-  - which perl
-  - perl --version
+  - echo $CC
   - sudo perl Makefile.pl --install
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+# Configuration file for continuous integration tests at travis-ci.org
+
+language: perl
+
+perl:
+#  - "5.16"
+#  - "5.14"
+  - "5.12"
+#  - "5.10"
+
+install:
+  - sudo perl Makefile.pl --install
+
+script:
+  - api-sanity-checker --test

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,18 @@ language: perl
 
 perl:
 #  - "5.16"
-#  - "5.14"
+  - "5.14"
   - "5.12"
 #  - "5.10"
 
+compiler:
+  - clang
+  - gcc
+
 install:
+  - echo "Using compiler: $CC"
+  - which perl
+  - perl --version
   - sudo perl Makefile.pl --install
 
 script:


### PR DESCRIPTION
Maybe this could be useful?

travis-ci is a free continuous integration service that integrates nicely with github and runs the api-sanity-checker tests for every commit and pull request using gcc and clang and different perl versions on Ubuntu.

It might not be very useful for you, because there's community of committers to your project, and you might have your own continuous integration system, but hey, it's free.

If you like it I can do the same for the other `lvc` repos.
