### PR TITLE
use env(1) in shebang

### DIFF
--- a/api-sanity-checker.pl
+++ b/api-sanity-checker.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 ###########################################################################
 # API Sanity Checker 1.98.3
 # An automatic generator of basic unit tests for a C/C++ library API


### PR DESCRIPTION
In a system that installed perl manually (e.g. /usr/local/bin/perl), we want to use that insted of system defaults (i.e. /usr/bin/perl).
