### PR TITLE
Fix deprecated unescaped brace in perl regex

### DIFF
--- a/api-sanity-checker.pl
+++ b/api-sanity-checker.pl
@@ -12226,7 +12226,7 @@ sub generateTest($)
     $SanityTest = correct_spaces($SanityTest); # cleaning code
     if(getTestLang($Interface) eq "C++" and getSymLang($Interface) eq "C")
     { # removing extended initializer lists
-        $SanityTest=~s/({\s*|\s)\.[a-z_][a-z_\d]*\s*=\s*/$1  /ig;
+        $SanityTest=~s/(\{\s*|\s)\.[a-z_][a-z_\d]*\s*=\s*/$1  /ig;
     }
     if(defined $Standalone)
     { # create stuff for building and running test


### PR DESCRIPTION
This fixes a deprecation warning when using Perl 5.30.0:
```
$ perl --version

This is perl 5, version 30, subversion 0 (v5.30.0) built for x86_64-linux-thread-multi

Copyright 1987-2019, Larry Wall

Perl may be copied only under the terms of either the Artistic License or the
GNU General Public License, which may be found in the Perl 5 source kit.

Complete documentation for Perl, including FAQ lists, should be found on
this system using "man perl" or "perldoc perl".  If you have access to the
Internet, point your browser at http://www.perl.org/, the Perl Home Page.

$ api-sanity-checker --version
Unescaped left brace in regex is deprecated here (and will be fatal in Perl 5.32), passed through in regex; marked by <-- HERE in m/({ <-- HERE \s*|\s)\.[a-z_][a-z_\d]*\s*=\s*/ at /nix/store/cm8sk6sdcwbh9jcplkh2n6ywnkyql7pc-api-sanity-checker-1.98.8/bin/api-sanity-checker line 12229.
API Sanity Checker 1.98.8
Copyright (C) 2018 Andrey Ponomarenko's ABI Laboratory
License: GNU LGPL 2.1 <http://www.gnu.org/licenses/>
This program is free software: you can redistribute it and/or modify it.

Written by Andrey Ponomarenko.
```